### PR TITLE
Implement unit movement, turn-start untap, and chain system

### DIFF
--- a/riftbound/backend/game_engine/chain/chain_manager.py
+++ b/riftbound/backend/game_engine/chain/chain_manager.py
@@ -53,6 +53,14 @@ class ChainManager:
             target_id=target_id
         )
         self.chain.append(link)
+        self.state.chain_items = [
+            {
+                "cardTitle": l.card.title,
+                "controllerId": l.controller.id,
+                "targetId": l.target_id,
+            }
+            for l in self.chain
+        ]
         
         self._emit("chain_link_added", {
             "card": card.title,
@@ -82,36 +90,97 @@ class ChainManager:
                 "controller": link.controller.id
             })
             
+            from ..effects.base import EffectContext
+            context = EffectContext(
+                state=self.state,
+                source_card=link.card,
+                controller=link.controller,
+                target_id=link.target_id,
+            )
+            
             if link.effect:
-                from ..effects.base import EffectContext
-                context = EffectContext(
-                    state=self.state,
-                    source_card=link.card,
-                    controller=link.controller,
-                    target_id=link.target_id
-                )
-                
                 try:
                     result = link.effect.execute(context)
                     
                     self._emit("effect_resolved", {
                         "card": link.card.title,
                         "effect": str(link.effect),
-                        "result": result
+                        "result": result,
                     })
                 except Exception as e:
                     self._emit("effect_error", {
                         "card": link.card.title,
                         "effect": str(link.effect),
-                        "error": str(e)
+                        "error": str(e),
                     })
+            elif getattr(link.card, "parsed_card", None) and getattr(link.card.parsed_card, "effects", None):
+                from ..triggers.condition import ConditionalEffect
+                from ..state import ActionType
+                
+                for effect_or_conditional in link.card.parsed_card.effects:
+                    if isinstance(effect_or_conditional, ConditionalEffect) or hasattr(effect_or_conditional, "condition"):
+                        conditional: ConditionalEffect = effect_or_conditional
+                        try:
+                            if conditional.check_condition(self.state, controller_id=link.controller.id):
+                                result = conditional.effect.execute(context)
+                                self._emit("effect_resolved", {
+                                    "card": link.card.title,
+                                    "effect": str(conditional.effect),
+                                    "result": result,
+                                })
+                            elif conditional.else_effect:
+                                result = conditional.else_effect.execute(context)
+                                self._emit("effect_resolved", {
+                                    "card": link.card.title,
+                                    "effect": str(conditional.else_effect),
+                                    "result": result,
+                                })
+                            else:
+                                continue
+                        except Exception as e:
+                            self._emit("effect_error", {
+                                "card": link.card.title,
+                                "effect": "conditional",
+                                "error": str(e),
+                            })
+                            continue
+                    else:
+                        effect = effect_or_conditional
+                        try:
+                            result = effect.execute(context)
+                            self._emit("effect_resolved", {
+                                "card": link.card.title,
+                                "effect": str(effect),
+                                "result": result,
+                            })
+                            self.state.add_action(
+                                ActionType.ACTIVATE_ABILITY,
+                                link.controller.id,
+                                {"type": "spell_effect", "card": link.card.title, "result": result},
+                            )
+                        except Exception as e:
+                            self._emit("effect_error", {
+                                "card": link.card.title,
+                                "effect": str(effect),
+                                "error": str(e),
+                            })
             
             link.resolved = True
             
             if link.card.card_type == "spell":
                 link.controller.graveyard.append(link.card)
+            
+            self.state.chain_items = [
+                {
+                    "cardTitle": l.card.title,
+                    "controllerId": l.controller.id,
+                    "targetId": l.target_id,
+                }
+                for l in self.chain
+            ]
         
         self.resolving = False
+        self.state.chain_items = []
         
         self._emit("chain_resolved", {"chain_size": 0})
     

--- a/riftbound/backend/game_engine/chain/priority.py
+++ b/riftbound/backend/game_engine/chain/priority.py
@@ -13,6 +13,7 @@ class PriorityManager:
     
     def give_priority_to(self, player: "Player"):
         self.priority_player_id = player.id
+        self.state.priority_player = player.id
         self.passed_players.clear()
     
     def has_priority(self, player: "Player") -> bool:
@@ -30,6 +31,7 @@ class PriorityManager:
             return True
         
         self.priority_player_id = opponent_id
+        self.state.priority_player = opponent_id
         return False
     
     def all_passed(self) -> bool:
@@ -37,6 +39,7 @@ class PriorityManager:
     
     def reset(self):
         self.priority_player_id = None
+        self.state.priority_player = None
         self.passed_players.clear()
     
     def __repr__(self):

--- a/riftbound/backend/game_engine/engine.py
+++ b/riftbound/backend/game_engine/engine.py
@@ -303,6 +303,15 @@ class GameEngine:
         if cmd_type == "concede":
             return self._cmd_concede(player)
 
+        if self.state.waiting_for_response:
+            if cmd_type == "pass_priority":
+                return self._cmd_pass_priority(player)
+            if cmd_type == "play_card":
+                if not self.priority_manager.has_priority(player):
+                    return {"success": False, "error": "you don't have priority"}
+                return self._cmd_play_card(player, command)
+            return {"success": False, "error": "waiting for responses"}
+
         # check turn
         if player.id != current.id:
             return {"success": False, "error": "not your turn"}
@@ -320,6 +329,10 @@ class GameEngine:
             return self._cmd_activate_ability(player, command)
         elif cmd_type == "play_card":
             return self._cmd_play_card(player, command)
+        elif cmd_type == "move":
+            return self._cmd_move(player, command)
+        elif cmd_type == "pass_priority":
+            return self._cmd_pass_priority(player)
         elif cmd_type == "attack":
             return self._cmd_attack(player, command)
         else:
@@ -597,7 +610,6 @@ class GameEngine:
         battlefield_id = command.get("battlefieldId")
         target_id = command.get("targetInstanceId")
 
-        # find card in hand
         card = None
         card_idx = None
         for i, c in enumerate(player.hand):
@@ -609,28 +621,30 @@ class GameEngine:
         if not card:
             return {"success": False, "error": "card not in hand"}
 
-        # auto-pay power first (recycling can use already-tapped runes)
+        self.parse_card(card)
+
+        if self.state.waiting_for_response:
+            if not card.is_spell:
+                return {"success": False, "error": "can only respond with Reaction spells"}
+            from .parser.keywords import Keyword
+            keywords = (card.parsed_card.keywords if card.parsed_card else []) or []
+            if not any(k.keyword == Keyword.REACTION for k in keywords):
+                return {"success": False, "error": "can only respond with Reaction spells"}
+
         if not self._auto_pay_power(player, card.power_cost):
             return {
                 "success": False,
                 "error": "not enough matching-color runes in play to pay power",
             }
 
-        # auto-tap for energy then spend from rune pool
         if not self._auto_pay_energy(player, card.energy_cost):
             return {"success": False, "error": "not enough runes to tap for energy"}
         if card.energy_cost > 0 and not player.spend_energy(card.energy_cost):
             return {"success": False, "error": "failed to spend energy"}
 
-        # parse card if not already parsed
-        self.parse_card(card)
-        
-        # remove from hand
         player.hand.pop(card_idx)
 
-        # handle card based on type
         if card.is_unit:
-            # rule 352.2: by default, units can be played to your base or a battlefield you control
             if battlefield_id:
                 bf = next(
                     (b for b in self.state.battlefields if b.id == battlefield_id), None
@@ -645,81 +659,44 @@ class GameEngine:
                         "error": "can only play units to your base or a battlefield you control",
                     }
                 bf.add_unit(card, player.position)
-                card.exhaust()  # units enter exhausted
+                card.exhaust()
             else:
                 player.base_units.append(card)
                 card.exhaust()
-            
-            # register triggers for unit
+
             self.register_triggers(card)
-            
-            # fire play triggers
+
             event = TriggerEvent(
                 trigger_type=TriggerType.PLAY,
                 source=card,
-                player_id=player.id
+                player_id=player.id,
             )
             self.fire_triggers(event)
 
         elif card.is_spell:
-            # use parsed effects for spell resolution
-            if card.parsed_card and card.parsed_card.effects:
-                context = EffectContext(
-                    state=self.state,
-                    source_card=card,
-                    controller=player,
-                    target_id=target_id
-                )
-                
-                for effect_or_conditional in card.parsed_card.effects:
-                    # handle conditional effects
-                    if hasattr(effect_or_conditional, 'condition'):
-                        from .triggers.condition import ConditionalEffect
-                        conditional: ConditionalEffect = effect_or_conditional
-                        
-                        if conditional.check_condition(self.state, controller_id=player.id):
-                            result = conditional.effect.execute(context)
-                            self._emit("effect_resolved", {
-                                "card": card.title,
-                                "effect": str(conditional.effect),
-                                "result": result
-                            })
-                        elif conditional.else_effect:
-                            result = conditional.else_effect.execute(context)
-                            self._emit("effect_resolved", {
-                                "card": card.title,
-                                "effect": str(conditional.else_effect),
-                                "result": result
-                            })
-                    else:
-                        # regular effect
-                        effect = effect_or_conditional
-                        result = effect.execute(context)
-                        
-                        # check if this was a damage effect that killed
-                        if hasattr(effect, 'killed_target') and effect.killed_target:
-                            context.additional_data['killed'] = True
-                        
-                        self._emit("effect_resolved", {
-                            "card": card.title,
-                            "effect": str(effect),
-                            "result": result
-                        })
-                        
-                        self.state.add_action(
-                            ActionType.ACTIVATE_ABILITY,
-                            player.id,
-                            {"type": "spell_effect", "card": card.title, "result": result},
-                        )
-            
-            # spells resolve and go to graveyard
-            player.graveyard.append(card)
+            self.chain_manager.add_to_chain(card, player, target_id=target_id)
+
+            opponent = self.state.get_opponent(player.id)
+            self.priority_manager.give_priority_to(opponent)
+            self.state.waiting_for_response = True
+
+            self.state.add_action(
+                ActionType.PLAY_CARD,
+                player.id,
+                {"cardName": card.title, "battlefield": battlefield_id},
+            )
+
+            self._emit(
+                "chain_updated",
+                {"chain": self.state.chain_items, "priorityPlayer": opponent.id},
+            )
+
+            return {"success": True, "waitingForResponse": True}
+
         elif card.card_type == "gear":
-            # rule 147: gear can only be played to your base and enters ready
             player.base_gear.append(card)
             card.ready()
         else:
-            # other cards
             player.graveyard.append(card)
 
         self.state.add_action(
@@ -727,6 +704,107 @@ class GameEngine:
             player.id,
             {"cardName": card.title, "battlefield": battlefield_id},
         )
+        return {"success": True}
+
+    def _cmd_pass_priority(self, player: Player) -> dict:
+        if not self.state.waiting_for_response:
+            return {"success": False, "error": "not waiting for response"}
+
+        if not self.priority_manager.has_priority(player):
+            return {"success": False, "error": "you don't have priority"}
+
+        all_passed = self.priority_manager.pass_priority(player)
+
+        if all_passed:
+            self.chain_manager.resolve_chain()
+            self.state.waiting_for_response = False
+            self.priority_manager.reset()
+            self.state.priority_player = None
+        else:
+            self.state.priority_player = self.priority_manager.priority_player_id
+            self._emit(
+                "priority_changed", {"priorityPlayer": self.priority_manager.priority_player_id}
+            )
+
+        return {"success": True}
+
+    def _cmd_move(self, player: Player, command: dict) -> dict:
+        if self.state.phase != GamePhase.MAIN:
+            return {"success": False, "error": "can only move during main phase"}
+
+        unit_id = command.get("unitInstanceId")
+        destination = command.get("destination")
+
+        if not isinstance(unit_id, str) or not unit_id:
+            return {"success": False, "error": "unitInstanceId required"}
+        if not isinstance(destination, str) or not destination:
+            return {"success": False, "error": "destination required"}
+
+        unit = None
+        source_bf = None
+
+        for u in player.base_units:
+            if u.instance_id == unit_id:
+                unit = u
+                break
+
+        if not unit:
+            for bf in self.state.battlefields:
+                units = bf.player1_units if player.position == "player1" else bf.player2_units
+                for u in units:
+                    if u.instance_id == unit_id:
+                        unit = u
+                        source_bf = bf
+                        break
+                if unit:
+                    break
+
+        if not unit:
+            return {"success": False, "error": "unit not found"}
+
+        if unit.exhausted:
+            return {"success": False, "error": "unit is exhausted"}
+
+        if source_bf is None:
+            if destination == "base":
+                return {"success": False, "error": "unit is already at base"}
+            bf = next((b for b in self.state.battlefields if b.id == destination), None)
+            if not bf:
+                return {"success": False, "error": "invalid destination"}
+            try:
+                player.base_units.remove(unit)
+            except ValueError:
+                return {"success": False, "error": "unit not found"}
+            bf.add_unit(unit, player.position)
+        else:
+            if destination == "base":
+                removed = source_bf.remove_unit(unit_id)
+                if not removed:
+                    return {"success": False, "error": "unit not found"}
+                player.base_units.append(removed)
+            else:
+                return {
+                    "success": False,
+                    "error": "cannot move between battlefields without Ganking",
+                }
+
+        unit.exhaust()
+
+        self.state.add_action(
+            ActionType.MOVE_UNIT,
+            player.id,
+            {"unitName": unit.title, "destination": destination},
+        )
+
+        self._emit(
+            "unit_moved",
+            {
+                "unitInstanceId": unit.instance_id,
+                "player": player.position,
+                "destination": destination,
+            },
+        )
+
         return {"success": True}
 
     def _cmd_attack(self, player: Player, command: dict) -> dict:

--- a/riftbound/backend/game_engine/state.py
+++ b/riftbound/backend/game_engine/state.py
@@ -363,9 +363,13 @@ class Player:
         return self.spend_energy(amount)
 
     def ready_all(self):
-        """ready all exhausted runes and units"""
+        """ready all exhausted runes and base permanents"""
         for rune in self.runes_in_play:
             rune.ready()
+        for gear in self.base_gear:
+            gear.ready()
+        for unit in self.base_units:
+            unit.ready()
 
     def shuffle_deck(self):
         random.shuffle(self.main_deck)
@@ -434,6 +438,11 @@ class GameState:
 
     # winner
     winner: Optional[str] = None
+
+    # chain state
+    chain_items: list[dict] = field(default_factory=list)
+    priority_player: Optional[str] = None
+    waiting_for_response: bool = False
 
     # game constants
     # per rules: start with 4 cards, then draw 1 at start of your first turn (so you see 5 on turn 1)

--- a/riftbound/backend/modules/games.py
+++ b/riftbound/backend/modules/games.py
@@ -98,6 +98,9 @@ class GameSession:
             "currentTurn": self.state.current_turn if self.state else None,
             "turnNumber": self.state.turn_number if self.state else 0,
             "phase": self.state.phase.value if self.state else None,
+            "chainItems": self.state.chain_items if self.state else [],
+            "priorityPlayer": self.state.priority_player if self.state else None,
+            "waitingForResponse": self.state.waiting_for_response if self.state else False,
             "setup": {
                 "step": self.state.setup_step,
                 "mulliganPlayer": self.state.mulligan_player,

--- a/riftbound/frontend/src/components/ChainDisplay.tsx
+++ b/riftbound/frontend/src/components/ChainDisplay.tsx
@@ -1,0 +1,61 @@
+import { useGameStore } from "@lib/store";
+import { cn } from "@lib/utils";
+import { Button } from "@theme/index";
+
+export function ChainDisplay() {
+  const { gameState, myPlayerId, sendCommand } = useGameStore();
+
+  if (!gameState) return null;
+
+  const chain = gameState.chainItems || [];
+  const visible = gameState.waitingForResponse || chain.length > 0;
+  if (!visible) return null;
+
+  const hasPriority =
+    !!gameState.priorityPlayer &&
+    !!myPlayerId &&
+    gameState.priorityPlayer === myPlayerId;
+
+  return (
+    <div
+      className={cn(
+        "flex items-center gap-4 px-4 py-2 rounded-lg border",
+        "border-arcane/25 bg-shadow/30"
+      )}
+    >
+      <div className="text-xs text-text-dim uppercase tracking-wider">chain</div>
+
+      <div className="flex items-center gap-2 flex-wrap">
+        {chain.length === 0 ? (
+          <span className="text-xs text-text-dim/40">empty</span>
+        ) : (
+          chain.map((item, idx) => (
+            <span
+              key={`${item.controllerId}-${idx}`}
+              className={cn(
+                "text-xs font-display px-2 py-1 rounded-md border",
+                "border-mist/20 bg-void-deep/40"
+              )}
+            >
+              {item.cardTitle}
+            </span>
+          ))
+        )}
+      </div>
+
+      <div className="flex items-center gap-3 ml-auto">
+        <div className="text-xs text-text-dim">
+          priority: {hasPriority ? "you" : "opponent"}
+        </div>
+        <Button
+          variant="primary"
+          size="sm"
+          onClick={() => sendCommand({ type: "pass_priority" })}
+          disabled={!gameState.waitingForResponse || !hasPriority}
+        >
+          Pass
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/riftbound/frontend/src/components/GameBoard.tsx
+++ b/riftbound/frontend/src/components/GameBoard.tsx
@@ -8,6 +8,7 @@ export function GameBoard() {
   const {
     gameState,
     getMyPlayer,
+    isMyTurn,
     sendCommand,
     selectedCard,
     setSelectedCard,
@@ -29,26 +30,58 @@ export function GameBoard() {
 
   function handleBattlefieldClick(bfId: string) {
     if (selectedCard) {
-      // play card to battlefield
-      sendCommand({
-        type: "play_card",
-        cardInstanceId: selectedCard.instanceId,
-        battlefieldId: bfId,
-      });
-      setSelectedCard(null);
-    } else {
-      setSelectedBattlefield(bfId);
+      const inHand =
+        !!myPlayer?.hand?.some((c) => c.instanceId === selectedCard.instanceId);
+
+      if (inHand) {
+        sendCommand({
+          type: "play_card",
+          cardInstanceId: selectedCard.instanceId,
+          battlefieldId: bfId,
+        });
+        setSelectedCard(null);
+        return;
+      }
+
+      if ((selectedCard.type || "").toLowerCase() === "unit") {
+        sendCommand({
+          type: "move",
+          unitInstanceId: selectedCard.instanceId,
+          destination: bfId,
+        });
+        setSelectedCard(null);
+        return;
+      }
+
+      return;
     }
+
+    setSelectedBattlefield(bfId);
   }
 
   function handleBaseClick() {
-    if (selectedCard) {
-      // play card to base (no battlefieldId)
+    if (!selectedCard) return;
+
+    const inHand =
+      !!myPlayer?.hand?.some((c) => c.instanceId === selectedCard.instanceId);
+
+    if (inHand) {
       sendCommand({
         type: "play_card",
         cardInstanceId: selectedCard.instanceId,
       });
       setSelectedCard(null);
+      return;
+    }
+
+    if ((selectedCard.type || "").toLowerCase() === "unit") {
+      sendCommand({
+        type: "move",
+        unitInstanceId: selectedCard.instanceId,
+        destination: "base",
+      });
+      setSelectedCard(null);
+      return;
     }
   }
 
@@ -100,9 +133,26 @@ export function GameBoard() {
           {myBaseGear.map((g) => (
             <CardImage key={g.instanceId} card={g} size="xs" />
           ))}
-          {myBaseUnits.map((u) => (
-            <CardImage key={u.instanceId} card={u} size="xs" />
-          ))}
+          {myBaseUnits.map((u) => {
+            const isSelected = selectedCard?.instanceId === u.instanceId;
+            return (
+              <div
+                key={u.instanceId}
+                onClick={() => {
+                  if (!isMyTurn() || u.exhausted) return;
+                  setSelectedCard(isSelected ? null : u);
+                }}
+                className={cn(
+                  "transition-all",
+                  isMyTurn() && !u.exhausted && "cursor-pointer",
+                  isSelected && "ring-2 ring-arcane scale-105",
+                  u.exhausted && "opacity-60 rotate-6"
+                )}
+              >
+                <CardImage card={u} size="xs" />
+              </div>
+            );
+          })}
           {myBaseUnits.length === 0 && myBaseGear.length === 0 && (
             <span className="text-text-dim/40 text-xs">empty</span>
           )}

--- a/riftbound/frontend/src/components/GameControls.tsx
+++ b/riftbound/frontend/src/components/GameControls.tsx
@@ -2,6 +2,7 @@ import { motion } from "motion/react";
 import { useGameStore } from "@lib/store";
 import { Button } from "@theme/index";
 import { Flag } from "lucide-react";
+import { ChainDisplay } from "./ChainDisplay";
 
 export function GameControls() {
   const { gameState, isMyTurn, sendCommand, getMyPlayer } = useGameStore();
@@ -19,8 +20,7 @@ export function GameControls() {
   }
 
   return (
-    <div className="flex items-center justify-between px-6 py-4">
-      {/* turn/phase info */}
+    <div className="flex items-center gap-6 px-6 py-4">
       <div className="flex items-center gap-6">
         <div className="text-center">
           <p className="text-xs text-text-dim uppercase tracking-wider">Turn</p>
@@ -51,7 +51,10 @@ export function GameControls() {
         </div>
       </div>
 
-      {/* action buttons */}
+      <div className="flex-1 flex justify-center">
+        <ChainDisplay />
+      </div>
+
       <div className="flex items-center gap-4">
         <motion.div whileHover={{ scale: 1.05 }} whileTap={{ scale: 0.95 }}>
           <Button

--- a/riftbound/frontend/src/components/PlayerHand.tsx
+++ b/riftbound/frontend/src/components/PlayerHand.tsx
@@ -9,8 +9,13 @@ interface PlayerHandProps {
 }
 
 export function PlayerHand({ cards }: PlayerHandProps) {
-  const { selectedCard, setSelectedCard, isMyTurn, gameState } = useGameStore();
-  const canPlay = isMyTurn() && gameState?.phase === "main";
+  const { selectedCard, setSelectedCard, isMyTurn, gameState, myPlayerId } = useGameStore();
+  const canPlay =
+    gameState?.phase === "main" &&
+    (isMyTurn() ||
+      (gameState.waitingForResponse &&
+        !!myPlayerId &&
+        gameState.priorityPlayer === myPlayerId));
 
   function handleCardClick(card: CardInstance) {
     if (!canPlay) return;

--- a/riftbound/frontend/src/lib/store.ts
+++ b/riftbound/frontend/src/lib/store.ts
@@ -181,6 +181,46 @@ export const useGameStore = create<GameStore>((set, get) => ({
         });
         break;
 
+      case "chain_updated":
+        set((state) => {
+          if (!state.gameState) return state;
+          return {
+            gameState: {
+              ...state.gameState,
+              chainItems: event.chain,
+              priorityPlayer: event.priorityPlayer,
+              waitingForResponse: true,
+            },
+          };
+        });
+        break;
+
+      case "priority_changed":
+        set((state) => {
+          if (!state.gameState) return state;
+          return {
+            gameState: {
+              ...state.gameState,
+              priorityPlayer: event.priorityPlayer,
+            },
+          };
+        });
+        break;
+
+      case "chain_resolved":
+        set((state) => {
+          if (!state.gameState) return state;
+          return {
+            gameState: {
+              ...state.gameState,
+              chainItems: [],
+              priorityPlayer: null,
+              waitingForResponse: false,
+            },
+          };
+        });
+        break;
+
       case "game_over":
         set((state) => {
           if (!state.gameState) return state;

--- a/riftbound/frontend/src/types/game.ts
+++ b/riftbound/frontend/src/types/game.ts
@@ -39,6 +39,12 @@ export interface CardModifier {
   duration?: number;
 }
 
+export interface ChainItem {
+  cardTitle: string;
+  controllerId: string;
+  targetId?: string | null;
+}
+
 export interface Battlefield {
   id: string;
   name: string;
@@ -91,6 +97,11 @@ export interface GameState {
   turnNumber: number;
   phase: GamePhase;
 
+  // chain/priority
+  chainItems: ChainItem[];
+  priorityPlayer: string | null;
+  waitingForResponse: boolean;
+
   // setup state (mulligan etc)
   setup?: {
     step: "battlefields" | "mulligan" | "done";
@@ -139,6 +150,9 @@ export type GameEvent =
   | { type: "action"; action: GameAction }
   | { type: "phase_changed"; phase: GamePhase }
   | { type: "turn_changed"; player: PlayerPosition }
+  | { type: "chain_updated"; chain: ChainItem[]; priorityPlayer: string }
+  | { type: "priority_changed"; priorityPlayer: string }
+  | { type: "chain_resolved"; chain_size: number }
   | { type: "game_over"; winner: PlayerPosition }
   | { type: "error"; message: string };
 
@@ -147,6 +161,8 @@ export type GameCommand =
   | { type: "draw_card" }
   | { type: "channel_rune" }
   | { type: "play_card"; cardInstanceId: string; battlefieldId?: string; targetInstanceId?: string }
+  | { type: "move"; unitInstanceId: string; destination: string }
+  | { type: "pass_priority" }
   | { type: "attack"; attackerId: string; targetId: string; battlefieldId: string }
   | { type: "choose_battlefield"; cardId: string }
   | { type: "mulligan"; cardInstanceIds: string[] }


### PR DESCRIPTION
Implement three core game mechanics missing from Riftbound:

**Unit Movement (Rules 143.1–143.4)**
- New `move` command allows units to transition between base and controlled battlefields (costs exhaustion)
- Rejects battlefield-to-battlefield moves without Ganking keyword
- UI: select unit in base/battlefield, click destination to move
- Backend: `_cmd_move` validates phase, unit state, and control

**Turn-Start Untap (Rule 315.1)**
- Fixed `ready_all()` to untap all base permanents (runes, units, gear) at turn start
- Previously only untapped runes; units and gear now ready on awaken phase

**Chain & Priority System (Rules 326–336)**
- Spells now go on chain instead of resolving immediately
- Opponent receives priority to respond with Reaction spells
- Priority passes back-and-forth; when both pass, chain resolves LIFO
- Backend: integrated `ChainManager` + `PriorityManager`, synced state to game serialization
- Frontend: added `ChainDisplay` component with Pass button, reaction spells playable from hand during chain
- Events: `chain_updated`, `priority_changed`, `chain_resolved`

Changes preserve all existing card play, attack, and resource mechanics while enabling interactive spell responses.

<a href="https://capy.ai/project/a2088422-0191-4c13-8c45-d46a8d4cb6af/task/9dcd6529-aa3e-4d19-a9e6-f31a357849ae"><img alt="Review with Capy" src="https://capy.ai/review-with-capy.svg"></a>