### PR TITLE
Refine Riftbound frontend for polished feel

### DIFF
--- a/riftbound/frontend/src/components/ChainDisplay.tsx
+++ b/riftbound/frontend/src/components/ChainDisplay.tsx
@@ -1,0 +1,60 @@
+import { Button } from "@theme/index";
+import { useGameStore } from "@lib/store";
+
+type ChainItem = {
+  cardTitle: string;
+};
+
+type ChainGameState = {
+  waitingForResponse?: boolean;
+  chainItems?: ChainItem[];
+  priorityPlayer?: string | null;
+};
+
+export function ChainDisplay() {
+  const { gameState, sendCommand, myPlayerId } = useGameStore();
+  const chainState = gameState as unknown as ChainGameState | null;
+
+  const chainItems = chainState?.chainItems ?? [];
+  const waitingForResponse = !!chainState?.waitingForResponse;
+
+  if (!waitingForResponse || chainItems.length === 0) {
+    return null;
+  }
+
+  const hasPriority = chainState?.priorityPlayer === myPlayerId;
+
+  return (
+    <div className="absolute inset-x-0 top-16 flex justify-center pointer-events-none z-40">
+      <div className="bg-void-deep/85 backdrop-blur-sm rounded-lg px-4 py-3 shadow-[0_0_34px_rgba(0,0,0,0.55)] pointer-events-auto">
+        <div className="text-[10px] uppercase tracking-wider text-text-dim mb-2">
+          Chain
+        </div>
+
+        <div className="flex flex-wrap gap-2">
+          {chainItems.map((item, idx) => (
+            <div
+              key={idx}
+              className="text-xs text-text bg-shadow/30 rounded px-2 py-1"
+            >
+              {item.cardTitle}
+            </div>
+          ))}
+        </div>
+
+        {hasPriority && (
+          <div className="mt-3 flex items-center gap-3">
+            <Button
+              size="sm"
+              variant="primary"
+              onClick={() => sendCommand({ type: "pass_priority" })}
+            >
+              Pass
+            </Button>
+            <span className="text-xs text-text-dim">or play a Reaction</span>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/riftbound/frontend/src/components/GameBoard.tsx
+++ b/riftbound/frontend/src/components/GameBoard.tsx
@@ -29,7 +29,6 @@ export function GameBoard() {
 
   function handleBattlefieldClick(bfId: string) {
     if (selectedCard) {
-      // play card to battlefield
       sendCommand({
         type: "play_card",
         cardInstanceId: selectedCard.instanceId,
@@ -43,7 +42,6 @@ export function GameBoard() {
 
   function handleBaseClick() {
     if (selectedCard) {
-      // play card to base (no battlefieldId)
       sendCommand({
         type: "play_card",
         cardInstanceId: selectedCard.instanceId,
@@ -53,25 +51,23 @@ export function GameBoard() {
   }
 
   return (
-    <div className="absolute inset-0 flex flex-col items-center justify-center p-6 gap-8">
-      {/* enemy base placeholder */}
-      <div className="w-full max-w-5xl border border-mist/20 bg-shadow/20 p-3">
-        <div className="text-xs text-text-dim uppercase tracking-wider mb-2">
-          enemy base
+    <div className="absolute inset-0 flex flex-col items-center justify-center p-4 gap-6">
+      <div className="w-full max-w-5xl rounded-lg bg-shadow/20 px-4 py-3">
+        <div className="text-[10px] text-text-dim/60 uppercase tracking-wider mb-2">
+          opponent base
         </div>
         <div className="flex gap-2 min-h-[56px] opacity-60">
           <span className="text-text-dim/40 text-xs">hidden</span>
         </div>
       </div>
 
-      {/* battlefields */}
-      <div className="flex gap-10">
+      <div className="w-full max-w-6xl flex flex-wrap justify-center gap-6">
         {gameState.battlefields.map((bf, index) => (
           <motion.div
             key={bf.id}
-            initial={{ opacity: 0, y: 20 }}
+            initial={{ opacity: 0, y: 12 }}
             animate={{ opacity: 1, y: 0 }}
-            transition={{ delay: index * 0.1 }}
+            transition={{ delay: index * 0.06 }}
           >
             <BattlefieldZone
               battlefield={bf}
@@ -83,17 +79,14 @@ export function GameBoard() {
         ))}
       </div>
 
-      {/* your base */}
       <div
         className={cn(
-          "w-full max-w-5xl border bg-shadow/30 p-3 transition-all duration-300",
-          "border-arcane/20",
-          selectedCard &&
-            "cursor-pointer hover:border-arcane/60 hover:bg-arcane/5"
+          "w-full max-w-5xl rounded-lg bg-shadow/30 px-4 py-3 transition-colors",
+          selectedCard && "cursor-pointer hover:bg-arcane/5"
         )}
         onClick={selectedCard ? handleBaseClick : undefined}
       >
-        <div className="text-xs text-text-dim uppercase tracking-wider mb-2">
+        <div className="text-[10px] text-text-dim/60 uppercase tracking-wider mb-2">
           your base
         </div>
         <div className="flex gap-3 min-h-[56px] flex-wrap">
@@ -128,21 +121,15 @@ function BattlefieldZone({
   const { sendCommand } = useGameStore();
 
   const opponentUnits =
-    myPosition === "player1"
-      ? battlefield.player2Units
-      : battlefield.player1Units;
+    myPosition === "player1" ? battlefield.player2Units : battlefield.player1Units;
   const myUnits =
-    myPosition === "player1"
-      ? battlefield.player1Units
-      : battlefield.player2Units;
+    myPosition === "player1" ? battlefield.player1Units : battlefield.player2Units;
 
-  const controlColor = {
-    none: "border-mist/30",
-    player1:
-      myPosition === "player1" ? "border-success/50" : "border-danger/50",
-    player2:
-      myPosition === "player2" ? "border-success/50" : "border-danger/50",
-    contested: "border-shurima/50",
+  const controlBg = {
+    none: "bg-shadow/20",
+    player1: myPosition === "player1" ? "bg-success/5" : "bg-danger/5",
+    player2: myPosition === "player2" ? "bg-success/5" : "bg-danger/5",
+    contested: "bg-shurima/10",
   }[battlefield.control];
 
   function handleAttack(attackerId: string, targetId: string) {
@@ -158,6 +145,7 @@ function BattlefieldZone({
     const { selectedCard, setSelectedCard } = useGameStore.getState();
     if (!selectedCard) return;
     if ((selectedCard.type || "").toLowerCase() !== "spell") return;
+
     sendCommand({
       type: "play_card",
       cardInstanceId: selectedCard.instanceId,
@@ -171,90 +159,80 @@ function BattlefieldZone({
     <div
       onClick={canDrop ? onClick : undefined}
       className={cn(
-        "w-64 min-h-[480px] p-4 flex flex-col transition-all duration-300",
-        "border-2 rounded-lg bg-shadow/30",
-        controlColor,
-        battlefield.control === "contested" && "animate-pulse-contested",
-        canDrop && "cursor-pointer hover:bg-arcane/10 hover:border-arcane/50"
+        "w-56 min-h-[380px] p-3 flex flex-col rounded-lg transition-colors",
+        "shadow-[0_0_0_1px_rgba(160,155,140,0.10)]",
+        controlBg,
+        canDrop &&
+          "cursor-pointer hover:bg-arcane/10 hover:shadow-[0_0_0_1px_rgba(200,170,110,0.35)]"
       )}
     >
-      {/* battlefield card (center anchor) */}
-      <div className="flex flex-col items-center mb-4">
+      <div className="flex flex-col items-center mb-3">
         {battlefield.card ? (
-          <motion.div
-            initial={{ opacity: 0, scale: 0.9 }}
-            animate={{ opacity: 1, scale: 1 }}
-            className="animate-float-gentle"
-          >
-            <CardImage card={battlefield.card} size="md" className="w-48" />
+          <motion.div initial={{ opacity: 0 }} animate={{ opacity: 1 }}>
+            <CardImage card={battlefield.card} size="md" />
           </motion.div>
         ) : (
-          <div className="w-48 aspect-4/3 border border-arcane/20 bg-void-deep/60 flex items-center justify-center">
-            <span className="font-display text-xs uppercase tracking-wider text-arcane text-center px-2">
+          <div className="w-32 aspect-[4/3] bg-void-deep/40 rounded flex items-center justify-center">
+            <span className="text-xs text-text-dim text-center px-2">
               {battlefield.name}
             </span>
           </div>
         )}
+
         {battlefield.control !== "none" && (
-          <motion.div
-            initial={{ opacity: 0 }}
-            animate={{ opacity: 1 }}
+          <span
             className={cn(
-              "text-xs mt-2 font-display uppercase tracking-wider",
+              "text-[10px] mt-1 uppercase tracking-wider",
               battlefield.control === "contested"
                 ? "text-shurima"
                 : battlefield.control === myPosition
-                ? "text-success"
-                : "text-danger"
+                ? "text-success/70"
+                : "text-danger/70"
             )}
           >
             {battlefield.control === "contested"
               ? "contested"
               : battlefield.control === myPosition
-              ? "you control"
-              : "enemy controls"}
-          </motion.div>
+              ? "controlled"
+              : "enemy"}
+          </span>
         )}
       </div>
 
-      {/* opponent's units (top) */}
-      <div className="flex-1 flex flex-col gap-2 items-center justify-end pb-3 border-b border-arcane/20">
-        <span className="text-xs text-text-dim mb-1 uppercase tracking-wider">enemy</span>
-        {opponentUnits.length === 0 ? (
-          <div className="text-text-dim/30 text-xs">empty</div>
-        ) : (
-          opponentUnits.map((unit) => (
-            <UnitCard
-              key={unit.instanceId}
-              unit={unit}
-              isEnemy
-              onClick={(targetId) => {
-                // if we have a selected spell, cast at target; else attack if selected attacker
-                const { selectedCard: sel } = useGameStore.getState();
-                if (sel && (sel.type || "").toLowerCase() === "spell") {
-                  handleSpellTarget(targetId);
-                  return;
-                }
-                if (
-                  sel &&
-                  myUnits.some((u) => u.instanceId === sel.instanceId)
-                ) {
-                  handleAttack(sel.instanceId, targetId);
-                }
-              }}
-            />
-          ))
-        )}
-      </div>
+      <div className="flex-1 flex flex-col gap-2">
+        <div className="flex-1 flex flex-wrap gap-1 justify-center content-end">
+          {opponentUnits.length === 0 ? (
+            <span className="text-text-dim/30 text-[10px]">empty</span>
+          ) : (
+            opponentUnits.map((unit) => (
+              <UnitCard
+                key={unit.instanceId}
+                unit={unit}
+                isEnemy
+                onClick={(targetId) => {
+                  const { selectedCard: sel } = useGameStore.getState();
+                  if (sel && (sel.type || "").toLowerCase() === "spell") {
+                    handleSpellTarget(targetId);
+                    return;
+                  }
+                  if (sel && myUnits.some((u) => u.instanceId === sel.instanceId)) {
+                    handleAttack(sel.instanceId, targetId);
+                  }
+                }}
+              />
+            ))
+          )}
+        </div>
 
-      {/* my units (bottom) */}
-      <div className="flex-1 flex flex-col gap-2 items-center justify-start pt-3">
-        <span className="text-xs text-text-dim mb-1 uppercase tracking-wider">you</span>
-        {myUnits.length === 0 ? (
-          <div className="text-text-dim/30 text-xs">empty</div>
-        ) : (
-          myUnits.map((unit) => <UnitCard key={unit.instanceId} unit={unit} />)
-        )}
+        <div className="h-px bg-mist/20 mx-4" />
+
+        <div className="flex-1 flex flex-wrap gap-1 justify-center content-start">
+          {myUnits.length === 0 ? (
+            <span className="text-text-dim/30 text-[10px]">empty</span>
+          ) : (
+            myUnits.map((unit) => <UnitCard key={unit.instanceId} unit={unit} />)
+          )}
+        </div>
       </div>
     </div>
   );
@@ -270,11 +248,15 @@ function UnitCard({ unit, isEnemy, onClick }: UnitCardProps) {
   const { selectedCard, setSelectedCard, isMyTurn } = useGameStore();
   const isSelected = selectedCard?.instanceId === unit.instanceId;
 
+  const isInteractive =
+    (isEnemy && !!onClick) || (!isEnemy && isMyTurn() && !unit.exhausted);
+
   function handleClick() {
     if (isEnemy && onClick) {
       onClick(unit.instanceId);
-    } else if (!isEnemy && isMyTurn() && !unit.exhausted) {
-      // select own unit for attacking
+      return;
+    }
+    if (!isEnemy && isMyTurn() && !unit.exhausted) {
       if (isSelected) {
         setSelectedCard(null);
       } else {
@@ -287,15 +269,14 @@ function UnitCard({ unit, isEnemy, onClick }: UnitCardProps) {
     <div
       onClick={handleClick}
       className={cn(
-        "relative cursor-pointer transition-all",
-        isSelected && "ring-2 ring-arcane scale-105",
-        unit.exhausted && "opacity-60 rotate-6"
+        "relative transition-transform",
+        isInteractive ? "cursor-pointer" : "cursor-default",
+        isSelected && "-translate-y-1 shadow-[0_0_0_2px_rgba(200,170,110,0.50)]"
       )}
     >
       <CardImage card={unit} size="xs" />
 
-      {/* stats overlay */}
-      <div className="absolute bottom-0 left-0 right-0 flex justify-between px-1 text-xs font-bold">
+      <div className="absolute bottom-0 left-0 right-0 flex justify-between px-1 pb-0.5 text-[10px] font-bold">
         <span className="text-danger">{unit.attack}</span>
         <span className="text-success">{unit.currentHealth - unit.damage}</span>
       </div>

--- a/riftbound/frontend/src/components/GameControls.tsx
+++ b/riftbound/frontend/src/components/GameControls.tsx
@@ -1,10 +1,9 @@
-import { motion } from "motion/react";
 import { useGameStore } from "@lib/store";
 import { Button } from "@theme/index";
 import { Flag } from "lucide-react";
 
 export function GameControls() {
-  const { gameState, isMyTurn, sendCommand, getMyPlayer } = useGameStore();
+  const { isMyTurn, sendCommand, getMyPlayer } = useGameStore();
   const myTurn = isMyTurn();
   const myPlayer = getMyPlayer();
 
@@ -19,66 +18,38 @@ export function GameControls() {
   }
 
   return (
-    <div className="flex items-center justify-between px-6 py-4">
-      {/* turn/phase info */}
-      <div className="flex items-center gap-6">
-        <div className="text-center">
-          <p className="text-xs text-text-dim uppercase tracking-wider">Turn</p>
-          <motion.p
-            key={gameState?.turnNumber}
-            initial={{ scale: 1.2, color: "var(--color-arcane-glow)" }}
-            animate={{ scale: 1, color: "var(--color-arcane)" }}
-            transition={{ duration: 0.3 }}
-            className="font-display text-2xl text-arcane"
-          >
-            {gameState?.turnNumber || 1}
-          </motion.p>
-        </div>
-        <div className="h-10 w-px bg-arcane/30" />
-        <div className="text-center">
-          <p className="text-xs text-text-dim uppercase tracking-wider">
-            Energy
-          </p>
-          <motion.p
-            key={myPlayer?.energy}
-            initial={{ scale: 1.2 }}
-            animate={{ scale: 1 }}
-            transition={{ duration: 0.3 }}
-            className="font-display text-2xl text-shurima"
-          >
-            {myPlayer?.energy || 0}
-          </motion.p>
-        </div>
+    <div className="flex items-center gap-4">
+      <div className="flex items-baseline gap-2">
+        <span className="hidden sm:inline text-[10px] text-text-dim/60 uppercase tracking-wider">
+          Score
+        </span>
+        <span className="font-display text-base sm:text-lg text-arcane tabular-nums">
+          {myPlayer?.score || 0}
+        </span>
       </div>
 
-      {/* action buttons */}
-      <div className="flex items-center gap-4">
-        <motion.div whileHover={{ scale: 1.05 }} whileTap={{ scale: 0.95 }}>
-          <Button
-            variant="primary"
-            size="sm"
-            onClick={handleEndTurn}
-            disabled={!myTurn}
-            className="px-6 py-2"
-          >
-            End Turn
-          </Button>
-        </motion.div>
-
-        <motion.div
-          whileHover={{ scale: 1.1, rotate: 5 }}
-          whileTap={{ scale: 0.9 }}
-        >
-          <Button
-            variant="ghost"
-            size="sm"
-            onClick={handleConcede}
-            className="text-text-dim hover:text-danger transition-colors duration-300"
-          >
-            <Flag size={16} />
-          </Button>
-        </motion.div>
+      <div className="hidden md:block text-xs text-text-dim/60 whitespace-nowrap">
+        H {myPlayer?.hand?.length || 0} • D {myPlayer?.mainDeckSize || 0}
       </div>
+
+      <Button
+        variant="primary"
+        size="sm"
+        onClick={handleEndTurn}
+        disabled={!myTurn}
+      >
+        End Turn
+      </Button>
+
+      <Button
+        variant="ghost"
+        size="sm"
+        onClick={handleConcede}
+        className="px-2 text-text-dim hover:text-danger"
+        aria-label="Concede"
+      >
+        <Flag size={16} />
+      </Button>
     </div>
   );
 }

--- a/riftbound/frontend/src/components/GameLog.tsx
+++ b/riftbound/frontend/src/components/GameLog.tsx
@@ -1,5 +1,6 @@
-import { useRef, useEffect } from "react";
-import { motion, AnimatePresence } from "motion/react";
+import { useEffect, useRef, useState } from "react";
+import { AnimatePresence, motion } from "motion/react";
+import { ScrollText, X } from "lucide-react";
 import { useGameStore } from "@lib/store";
 import { cn } from "@lib/utils";
 import type { GameAction } from "@/types";
@@ -7,55 +8,78 @@ import type { GameAction } from "@/types";
 export function GameLog() {
   const { gameState } = useGameStore();
   const scrollRef = useRef<HTMLDivElement>(null);
+  const [collapsed, setCollapsed] = useState(true);
 
-  // auto-scroll to bottom on new actions
   useEffect(() => {
-    if (scrollRef.current) {
-      scrollRef.current.scrollTop = scrollRef.current.scrollHeight;
-    }
-  }, [gameState?.actionLog.length]);
+    if (collapsed) return;
+    if (!scrollRef.current) return;
+    scrollRef.current.scrollTop = scrollRef.current.scrollHeight;
+  }, [collapsed, gameState?.actionLog.length]);
+
+  const actions = gameState?.actionLog ?? [];
 
   return (
-    <div className="absolute right-6 top-6 bottom-6 w-72 bg-void-deep/90 backdrop-blur-md border border-arcane/20 rounded-lg overflow-hidden flex flex-col shadow-[0_0_40px_rgba(0,0,0,0.6)]">
-      {/* header */}
-      <div className="px-4 py-3 border-b border-arcane/20 bg-shadow/30">
-        <h3 className="font-display text-sm uppercase tracking-wider text-arcane">
-          Game Log
-        </h3>
-      </div>
-
-      {/* log entries */}
-      <div ref={scrollRef} className="flex-1 overflow-y-auto p-3 space-y-2">
-        <AnimatePresence initial={false}>
-          {gameState?.actionLog.map((action, index) => (
-            <motion.div
-              key={action.id}
-              initial={{ opacity: 0, x: 30, scale: 0.95 }}
-              animate={{ 
-                opacity: 1, 
-                x: 0, 
-                scale: 1,
-                transition: { 
-                  type: "spring",
-                  stiffness: 300,
-                  damping: 25,
-                  delay: index * 0.02
-                }
-              }}
-              exit={{ opacity: 0, x: -20, transition: { duration: 0.2 } }}
+    <div
+      className={cn(
+        "absolute right-4 top-4 z-40 transition-all",
+        collapsed ? "w-9 h-9" : "w-72 max-h-[60vh]"
+      )}
+    >
+      {collapsed ? (
+        <button
+          onClick={() => setCollapsed(false)}
+          className={cn(
+            "w-9 h-9 rounded-lg bg-void-deep/70 backdrop-blur-sm",
+            "shadow-[0_0_24px_rgba(0,0,0,0.45)]",
+            "flex items-center justify-center",
+            "text-text-dim hover:text-arcane transition-colors",
+            "focus:outline-none focus:ring-2 focus:ring-arcane/30"
+          )}
+          aria-label="Open game log"
+        >
+          <ScrollText size={16} />
+        </button>
+      ) : (
+        <div className="bg-void-deep/85 backdrop-blur-sm rounded-lg overflow-hidden shadow-[0_0_34px_rgba(0,0,0,0.55)]">
+          <div className="px-3 py-2 flex items-center justify-between bg-shadow/20">
+            <span className="text-[10px] uppercase tracking-wider text-text-dim">
+              Log
+            </span>
+            <button
+              onClick={() => setCollapsed(true)}
+              className="text-text-dim hover:text-text transition-colors"
+              aria-label="Close game log"
             >
-              <LogEntry action={action} />
-            </motion.div>
-          ))}
-        </AnimatePresence>
+              <X size={16} />
+            </button>
+          </div>
 
-        {/* empty state */}
-        {(!gameState?.actionLog || gameState.actionLog.length === 0) && (
-          <p className="text-text-dim/50 text-xs text-center py-4">
-            no actions yet
-          </p>
-        )}
-      </div>
+          <div
+            ref={scrollRef}
+            className="max-h-[50vh] overflow-y-auto p-2 space-y-1"
+          >
+            {actions.length === 0 ? (
+              <p className="text-text-dim/50 text-xs text-center py-4">
+                no actions yet
+              </p>
+            ) : (
+              <AnimatePresence initial={false}>
+                {actions.map((action) => (
+                  <motion.div
+                    key={action.id}
+                    initial={{ opacity: 0, y: 6 }}
+                    animate={{ opacity: 1, y: 0 }}
+                    exit={{ opacity: 0, y: -6 }}
+                    transition={{ duration: 0.14 }}
+                  >
+                    <LogEntry action={action} />
+                  </motion.div>
+                ))}
+              </AnimatePresence>
+            )}
+          </div>
+        </div>
+      )}
     </div>
   );
 }
@@ -64,22 +88,26 @@ function LogEntry({ action }: { action: GameAction }) {
   const message = formatActionMessage(action);
 
   return (
-    <motion.div
-      whileHover={{ scale: 1.02, x: 4 }}
+    <div
       className={cn(
-        "px-3 py-2 text-xs rounded transition-all duration-300",
-        "bg-shadow/50 border-l-2 hover:bg-shadow/70",
-        getActionBorderColor(action.type)
+        "flex items-start gap-2 rounded px-2 py-1",
+        "bg-shadow/30 hover:bg-shadow/45 transition-colors"
       )}
     >
-      <span className="text-text-dim leading-relaxed">{message}</span>
-    </motion.div>
+      <span
+        className={cn(
+          "mt-1 w-1.5 h-1.5 rounded-full flex-shrink-0",
+          getActionDotColor(action.type)
+        )}
+      />
+      <span className="text-text-dim text-xs leading-relaxed">{message}</span>
+    </div>
   );
 }
 
 function formatActionMessage(action: GameAction): string {
   const data = action.data as Record<string, unknown>;
-  
+
   switch (action.type) {
     case "draw_card":
       if (data.type === "score") {
@@ -107,17 +135,17 @@ function formatActionMessage(action: GameAction): string {
   }
 }
 
-function getActionBorderColor(type: string): string {
+function getActionDotColor(type: string): string {
   switch (type) {
     case "play_card":
-      return "border-l-hextech";
+      return "bg-hextech";
     case "attack":
-      return "border-l-danger";
+      return "bg-danger";
     case "channel_rune":
-      return "border-l-shurima";
+      return "bg-shurima";
     case "end_turn":
-      return "border-l-arcane";
+      return "bg-arcane";
     default:
-      return "border-l-text-dim";
+      return "bg-text-dim";
   }
 }

--- a/riftbound/frontend/src/components/PlayerHand.tsx
+++ b/riftbound/frontend/src/components/PlayerHand.tsx
@@ -23,33 +23,41 @@ export function PlayerHand({ cards }: PlayerHandProps) {
   }
 
   return (
-    <div className="h-full flex items-center justify-center px-8">
-      <div className="flex gap-3 overflow-x-auto py-6">
+    <div className="h-full flex items-center justify-center px-2">
+      <div className="flex gap-2 overflow-x-auto py-4">
         {cards.map((card, index) => {
           const totalCards = cards.length;
           const middleIndex = (totalCards - 1) / 2;
           const offset = index - middleIndex;
-          const rotation = offset * 2;
-          const yOffset = Math.abs(offset) * 3;
-          
+          const rotation = offset * 1.25;
+          const yOffset = Math.abs(offset) * 2;
+
           return (
             <motion.div
               key={card.instanceId || index}
-              initial={{ opacity: 0, y: 50 }}
-              animate={{ 
-                opacity: 1, 
+              initial={{ opacity: 0, y: 18 }}
+              animate={{
+                opacity: 1,
                 y: yOffset,
                 rotate: rotation,
               }}
-              transition={{ delay: index * 0.05 }}
-              whileHover={canPlay ? { 
-                y: -30, 
-                scale: 1.08,
-                rotate: 0,
-                transition: { type: "spring", stiffness: 300, damping: 20 }
-              } : undefined}
+              transition={{ delay: index * 0.03 }}
+              whileHover={
+                canPlay
+                  ? {
+                      y: -18,
+                      scale: 1.05,
+                      rotate: 0,
+                      transition: {
+                        type: "spring",
+                        stiffness: 300,
+                        damping: 24,
+                      },
+                    }
+                  : undefined
+              }
               className={cn(
-                "relative transition-all card-lift-shadow",
+                "relative hover-lift",
                 canPlay ? "cursor-pointer" : "cursor-not-allowed opacity-60"
               )}
               onClick={() => handleCardClick(card)}

--- a/riftbound/frontend/src/components/RunesDisplay.tsx
+++ b/riftbound/frontend/src/components/RunesDisplay.tsx
@@ -1,8 +1,8 @@
-import { motion, AnimatePresence } from "motion/react";
-import { cn } from "@lib/utils";
+import { AnimatePresence, motion } from "motion/react";
+import { cn, getCardImageUrl } from "@lib/utils";
 import type { CardInstance } from "@/types";
 import { useGameStore } from "@lib/store";
-import { CardImage } from "./CardImage";
+import { useMemo } from "react";
 
 interface RunesDisplayProps {
   runes: CardInstance[];
@@ -11,61 +11,118 @@ interface RunesDisplayProps {
 export function RunesDisplay({ runes }: RunesDisplayProps) {
   const { sendCommand, isMyTurn, gameState } = useGameStore();
 
+  const canTapRunes = isMyTurn() && gameState?.phase === "main";
+
+  const groupedRunes = useMemo(() => {
+    const groups = new Map<string, CardInstance[]>();
+
+    for (const rune of runes) {
+      const color = rune.color || "colorless";
+      const existing = groups.get(color);
+      if (existing) {
+        existing.push(rune);
+      } else {
+        groups.set(color, [rune]);
+      }
+    }
+
+    return Array.from(groups.entries()).map(([color, colorRunes]) => ({
+      color,
+      runes: [...colorRunes].sort(
+        (a, b) => Number(b.exhausted) - Number(a.exhausted)
+      ),
+    }));
+  }, [runes]);
+
   if (runes.length === 0) {
-    return <span className="text-text-dim/50 text-xs">no runes channeled</span>;
+    return <span className="text-text-dim/40 text-xs">no runes</span>;
+  }
+
+  function handleRuneClick(rune: CardInstance) {
+    if (!canTapRunes || rune.exhausted) return;
+    sendCommand({ type: "tap_rune", runeInstanceId: rune.instanceId });
   }
 
   return (
-    <div className="flex gap-2">
-      <AnimatePresence mode="popLayout">
-        {runes.map((rune, index) => (
-          <motion.button
-            key={rune.instanceId}
-            initial={{ opacity: 0, scale: 0.8, y: 20 }}
-            animate={{
-              opacity: 1,
-              scale: 1,
-              y: 0,
-              transition: {
-                type: "spring",
-                stiffness: 300,
-                damping: 20,
-                delay: index * 0.05,
-              },
-            }}
-            exit={{ opacity: 0, scale: 0.8, transition: { duration: 0.2 } }}
-            whileHover={
-              !rune.exhausted
-                ? {
-                    scale: 1.1,
-                    y: -4,
-                    transition: { type: "spring", stiffness: 400, damping: 20 },
-                  }
-                : undefined
-            }
-            whileTap={!rune.exhausted ? { scale: 0.95 } : undefined}
-            className={cn(
-              "w-12 h-16 rounded border overflow-hidden transition-all duration-300",
-              rune.exhausted
-                ? "bg-mist/30 border-mist/50 text-text-dim opacity-50"
-                : "border-shurima/60 hover:border-arcane/80 rune-shimmer shadow-[0_0_15px_rgba(212,166,54,0.3)]"
+    <div className="flex flex-wrap items-center gap-4">
+      {groupedRunes.map(({ color, runes: colorRunes }) => {
+        const readyCount = colorRunes.filter((r) => !r.exhausted).length;
+        const total = colorRunes.length;
+
+        const cardW = 32;
+        const cardH = 44;
+        const overlap = 12;
+        const stackW = cardW + Math.max(0, total - 1) * overlap;
+
+        return (
+          <div key={color} className="flex items-center gap-2">
+            <div
+              className="relative"
+              style={{ width: `${stackW}px`, height: `${cardH}px` }}
+            >
+              <AnimatePresence initial={false}>
+                {colorRunes.map((rune, idx) => {
+                  const isInteractive = canTapRunes && !rune.exhausted;
+
+                  return (
+                    <motion.button
+                      key={rune.instanceId}
+                      initial={{ opacity: 0, x: -8 }}
+                      animate={{ opacity: 1, x: 0 }}
+                      exit={{ opacity: 0, x: -8 }}
+                      whileHover={
+                        isInteractive
+                          ? {
+                              y: -6,
+                              zIndex: 100,
+                              transition: {
+                                type: "spring",
+                                stiffness: 500,
+                                damping: 30,
+                              },
+                            }
+                          : undefined
+                      }
+                      whileTap={isInteractive ? { scale: 0.98 } : undefined}
+                      style={{ left: `${idx * overlap}px`, zIndex: idx }}
+                      title={`${rune.title}${rune.exhausted ? " (exhausted)" : ""}`}
+                      onClick={() => handleRuneClick(rune)}
+                      disabled={!isInteractive}
+                      className={cn(
+                        "absolute top-0 w-8 h-11 rounded border overflow-hidden bg-void-deep/40",
+                        "transition-transform duration-150",
+                        "focus:outline-none focus:ring-2 focus:ring-arcane/30",
+                        rune.exhausted
+                          ? "opacity-40 border-mist/30 pointer-events-none"
+                          : "border-shurima/50 hover:border-arcane hover:shadow-[0_0_14px_rgba(200,170,110,0.22)]"
+                      )}
+                    >
+                      <img
+                        src={getCardImageUrl(rune.set || "", rune.number || 0)}
+                        alt={rune.title}
+                        loading="lazy"
+                        className={cn(
+                          "w-full h-full object-cover",
+                          rune.exhausted && "grayscale"
+                        )}
+                        onError={(e) => {
+                          (e.currentTarget as HTMLImageElement).src = `https://placehold.co/64x88/1a1a2e/c8aa6e?text=${encodeURIComponent(rune.title)}`;
+                        }}
+                      />
+                    </motion.button>
+                  );
+                })}
+              </AnimatePresence>
+            </div>
+
+            {total > 1 && (
+              <span className="text-[10px] tabular-nums text-text-dim/60">
+                {readyCount}/{total}
+              </span>
             )}
-            title={`${rune.title}${rune.exhausted ? " (exhausted)" : ""}`}
-            disabled={
-              rune.exhausted || !isMyTurn() || gameState?.phase !== "main"
-            }
-            onClick={() => {
-              if (rune.exhausted) return;
-              sendCommand({
-                type: "tap_rune",
-                runeInstanceId: rune.instanceId,
-              });
-            }}
-          >
-            <CardImage card={rune} size="xs" className="w-full h-full" />
-          </motion.button>
-        ))}
-      </AnimatePresence>
+          </div>
+        );
+      })}
     </div>
   );
 }

--- a/riftbound/frontend/src/components/index.ts
+++ b/riftbound/frontend/src/components/index.ts
@@ -4,3 +4,4 @@ export { PlayerHand } from "./PlayerHand";
 export { GameControls } from "./GameControls";
 export { GameLog } from "./GameLog";
 export { RunesDisplay } from "./RunesDisplay";
+export { ChainDisplay } from "./ChainDisplay";

--- a/riftbound/frontend/src/index.css
+++ b/riftbound/frontend/src/index.css
@@ -149,7 +149,7 @@ body {
 }
 
 .animate-pulse-contested {
-  animation: pulse-contested 2s ease-in-out infinite;
+  animation: none;
 }
 
 /* card lift shadow */
@@ -165,13 +165,16 @@ body {
 
 /* shimmer effect for runes */
 .rune-shimmer {
-  background: linear-gradient(
-    90deg,
-    transparent 0%,
-    rgba(212, 166, 54, 0.2) 50%,
-    transparent 100%
-  );
-  background-size: 200% 100%;
-  animation: shimmer 3s ease-in-out infinite;
+  background: none;
+  animation: none;
+}
+
+.hover-lift {
+  transition: transform 0.2s ease;
+  will-change: transform;
+}
+
+.hover-lift:hover {
+  transform: translateY(-2px);
 }
 

--- a/riftbound/frontend/src/pages/Game.tsx
+++ b/riftbound/frontend/src/pages/Game.tsx
@@ -5,11 +5,12 @@ import { Copy, LogOut, Loader2 } from "lucide-react";
 import { useGameStore } from "@lib/store";
 import { connectToGame, disconnectFromGame } from "@lib/websocket";
 import { Button } from "@theme/index";
-import { cn } from "@lib/utils";
+import { cn, formatPhase } from "@lib/utils";
 import { GameBoard } from "@components/GameBoard";
 import { PlayerHand } from "@components/PlayerHand";
 import { GameControls } from "@components/GameControls";
 import { GameLog } from "@components/GameLog";
+import { ChainDisplay } from "@components/ChainDisplay";
 import { RunesDisplay } from "@components/RunesDisplay";
 import { CardImage } from "@components/CardImage";
 
@@ -19,7 +20,6 @@ export function Game() {
   const code = searchParams.get("code");
 
   const {
-    connected,
     connecting,
     gameState,
     myPlayerId,
@@ -35,19 +35,20 @@ export function Game() {
   const inBattlefieldPick = setup?.step === "battlefields";
   const inMulligan = setup?.step === "mulligan";
   const myPosition = myPlayer?.position;
-  const isMyMulligan = inMulligan && !!myPosition && setup?.mulliganPlayer === myPosition;
-  const myBattlefieldOptions = (myPosition && setup?.battlefieldOptions?.[myPosition]) || [];
-  const myBattlefieldSelected = (myPosition && setup?.battlefieldSelected?.[myPosition]) || null;
+  const isMyMulligan =
+    inMulligan && !!myPosition && setup?.mulliganPlayer === myPosition;
+  const myBattlefieldOptions =
+    (myPosition && setup?.battlefieldOptions?.[myPosition]) || [];
+  const myBattlefieldSelected =
+    (myPosition && setup?.battlefieldSelected?.[myPosition]) || null;
 
   const [mulliganIds, setMulliganIds] = useState<string[]>([]);
   const [mulliganSubmitting, setMulliganSubmitting] = useState(false);
   const [bfSubmitting, setBfSubmitting] = useState(false);
 
-  // connect on mount
   useEffect(() => {
     const qsPlayerId = searchParams.get("playerId");
     if (!myPlayerId && qsPlayerId) {
-      // allow deep links like /game/:id?playerId=foo (handy for debugging)
       setMyPlayerId(qsPlayerId);
     }
     if (gameId && myPlayerId) {
@@ -57,7 +58,6 @@ export function Game() {
     return () => disconnectFromGame();
   }, [gameId, myPlayerId, searchParams, setMyPlayerId]);
 
-  // reset selection when mulligan ownership changes
   useEffect(() => {
     setMulliganIds([]);
     setMulliganSubmitting(false);
@@ -81,8 +81,9 @@ export function Game() {
   function submitMulligan() {
     if (!isMyMulligan) return;
     setMulliganSubmitting(true);
-    // send mulligan even if empty (0 cards is valid)
-    useGameStore.getState().sendCommand({ type: "mulligan", cardInstanceIds: mulliganIds });
+    useGameStore
+      .getState()
+      .sendCommand({ type: "mulligan", cardInstanceIds: mulliganIds });
   }
 
   function chooseBattlefield(cardId: string) {
@@ -93,19 +94,23 @@ export function Game() {
     useGameStore.getState().sendCommand({ type: "choose_battlefield", cardId });
   }
 
-  // loading state
   if (connecting) {
     return (
       <div className="min-h-screen bg-void bg-hex-pattern flex items-center justify-center">
-        <motion.div initial={{ opacity: 0 }} animate={{ opacity: 1 }} className="text-center">
+        <motion.div
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          className="text-center"
+        >
           <Loader2 className="w-12 h-12 text-arcane animate-spin mx-auto mb-4" />
-          <p className="text-text-dim font-display uppercase tracking-wider">Connecting...</p>
+          <p className="text-text-dim font-display uppercase tracking-wider">
+            Connecting...
+          </p>
         </motion.div>
       </div>
     );
   }
 
-  // waiting for opponent
   if (gameState?.status === "waiting") {
     return (
       <div className="min-h-screen bg-void bg-hex-pattern flex items-center justify-center">
@@ -122,7 +127,9 @@ export function Game() {
           {code && (
             <div className="mb-8">
               <div className="flex items-center justify-center gap-4 p-6 bg-shadow/50 border-2 border-arcane/30">
-                <span className="font-display text-4xl text-arcane tracking-[0.5em]">{code}</span>
+                <span className="font-display text-4xl text-arcane tracking-[0.5em]">
+                  {code}
+                </span>
                 <button
                   onClick={() => navigator.clipboard.writeText(code)}
                   className="text-text-dim hover:text-arcane transition-colors"
@@ -142,7 +149,6 @@ export function Game() {
     );
   }
 
-  // game over
   if (gameState?.status === "finished") {
     const isWinner = gameState.winner === myPosition;
 
@@ -154,16 +160,18 @@ export function Game() {
           transition={{ type: "spring", stiffness: 200, damping: 20 }}
           className="text-center"
         >
-          <h1 className={cn(
-            "font-display text-6xl uppercase tracking-wider mb-4",
-            isWinner ? "text-success" : "text-danger"
-          )}>
+          <h1
+            className={cn(
+              "font-display text-6xl uppercase tracking-wider mb-4",
+              isWinner ? "text-success" : "text-danger"
+            )}
+          >
             {isWinner ? "Victory" : "Defeat"}
           </h1>
           <p className="text-text-dim mb-8">
             {isWinner ? "you have proven your worth" : "return stronger next time"}
           </p>
-          <Button variant="primary" onClick={() => window.location.href = "/"}>
+          <Button variant="primary" onClick={() => (window.location.href = "/")}>
             Return to Menu
           </Button>
         </motion.div>
@@ -173,66 +181,61 @@ export function Game() {
 
   return (
     <div className="h-screen bg-void overflow-hidden flex flex-col">
-      {/* opponent info bar */}
-      <div className="h-20 px-6 flex items-center justify-between border-b border-arcane/20 bg-void-deep/50 backdrop-blur-sm">
-        <div className="flex items-center gap-4">
-          <motion.div
-            animate={{ scale: opponent?.connected ? [1, 1.2, 1] : 1 }}
-            transition={{ duration: 1, repeat: Infinity, repeatDelay: 2 }}
+      <div className="h-12 px-4 flex items-center justify-between bg-void-deep/30">
+        <div className="flex items-center gap-3 min-w-0">
+          <span
             className={cn(
-              "w-3 h-3 rounded-full",
+              "w-2 h-2 rounded-full",
               opponent?.connected ? "bg-success" : "bg-danger"
             )}
           />
-          <span className="font-display text-lg text-text uppercase tracking-wider">
+          <span className="text-sm text-text-dim truncate">
             {opponent?.name || "Opponent"}
           </span>
+          <span className="text-arcane font-display tabular-nums">
+            {opponent?.score || 0}
+          </span>
+          <span className="hidden sm:inline text-xs text-text-dim/60 whitespace-nowrap">
+            H {opponent?.handSize || 0} • D {opponent?.mainDeckSize || 0}
+          </span>
         </div>
-        <div className="flex items-center gap-8">
-          <div className="text-center">
-            <p className="text-xs text-text-dim uppercase tracking-wider">Score</p>
-            <p className="font-display text-2xl text-arcane transition-all duration-300">{opponent?.score || 0}</p>
+
+        <div className="flex items-center gap-4">
+          <div className="text-xs text-text-dim whitespace-nowrap">
+            Turn {gameState?.turnNumber || 1} •{" "}
+            {gameState?.phase ? formatPhase(gameState.phase) : ""}
           </div>
-          <div className="h-8 w-px bg-arcane/20" />
-          <div className="text-center">
-            <p className="text-xs text-text-dim uppercase tracking-wider">Hand</p>
-            <p className="font-display text-xl text-text transition-all duration-300">{opponent?.handSize || 0}</p>
-          </div>
-          <div className="h-8 w-px bg-arcane/20" />
-          <div className="text-center">
-            <p className="text-xs text-text-dim uppercase tracking-wider">Deck</p>
-            <p className="font-display text-xl text-text transition-all duration-300">{opponent?.mainDeckSize || 0}</p>
-          </div>
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={() => (window.location.href = "/")}
+            className="px-2"
+          >
+            <LogOut size={18} />
+          </Button>
         </div>
       </div>
 
-      {/* main game area */}
       <div className="flex-1 relative">
         <GameBoard />
 
-        {/* turn indicator */}
         <AnimatePresence>
           {isMyTurn() && (
             <motion.div
-              initial={{ opacity: 0, scale: 0.8, y: -20 }}
-              animate={{ 
-                opacity: 1, 
-                scale: 1, 
-                y: 0,
-              }}
-              exit={{ opacity: 0, scale: 0.8, y: -20 }}
-              transition={{ type: "spring", stiffness: 300, damping: 20 }}
-              className="absolute top-6 left-1/2 -translate-x-1/2 px-8 py-3 bg-arcane text-void font-display uppercase tracking-wider text-lg shadow-[0_0_30px_rgba(200,170,110,0.6)]"
+              initial={{ opacity: 0, y: -10 }}
+              animate={{ opacity: 1, y: 0 }}
+              exit={{ opacity: 0, y: -10 }}
+              transition={{ duration: 0.18 }}
+              className="absolute top-3 left-1/2 -translate-x-1/2 px-4 py-1 bg-arcane/90 text-void text-xs font-display uppercase tracking-wider shadow-[0_0_18px_rgba(200,170,110,0.25)]"
             >
               Your Turn
             </motion.div>
           )}
         </AnimatePresence>
 
-        {/* game log */}
+        <ChainDisplay />
         <GameLog />
 
-        {/* battlefield pick overlay */}
         <AnimatePresence>
           {inBattlefieldPick && (
             <motion.div
@@ -244,7 +247,7 @@ export function Game() {
               <motion.div
                 initial={{ scale: 0.98, y: 10 }}
                 animate={{ scale: 1, y: 0 }}
-                className="w-full max-w-3xl bg-void-deep border-2 border-arcane/30 p-8 shadow-[0_0_60px_rgba(0,0,0,0.8)]"
+                className="w-full max-w-3xl bg-void-deep/95 border border-mist/20 rounded-lg p-6 shadow-[0_0_60px_rgba(0,0,0,0.8)]"
               >
                 <h2 className="font-display text-xl uppercase tracking-wider text-arcane mb-2">
                   choose your battlefield
@@ -270,7 +273,7 @@ export function Game() {
                         key={c.id}
                         onClick={() => chooseBattlefield(c.id)}
                         disabled={bfSubmitting}
-                        className="border-2 border-mist/30 hover:border-arcane/50 transition-all"
+                        className="rounded-md overflow-hidden border border-mist/30 hover:border-arcane/50 transition-colors"
                         title={c.title}
                       >
                         <CardImage card={c} size="md" className="w-full" />
@@ -283,7 +286,6 @@ export function Game() {
           )}
         </AnimatePresence>
 
-        {/* mulligan overlay */}
         <AnimatePresence>
           {inMulligan && (
             <motion.div
@@ -295,7 +297,7 @@ export function Game() {
               <motion.div
                 initial={{ scale: 0.98, y: 10 }}
                 animate={{ scale: 1, y: 0 }}
-                className="w-full max-w-2xl bg-void-deep border-2 border-arcane/30 p-6"
+                className="w-full max-w-2xl bg-void-deep/95 border border-mist/20 rounded-lg p-6"
               >
                 <h2 className="font-display text-xl uppercase tracking-wider text-arcane mb-2">
                   Mulligan
@@ -333,8 +335,10 @@ export function Game() {
                             key={c.instanceId}
                             onClick={() => toggleMulliganSelect(c.instanceId)}
                             className={cn(
-                              "relative border-2 transition-all",
-                              selected ? "border-arcane" : "border-mist/30 hover:border-arcane/50"
+                              "relative rounded-md overflow-hidden border transition-colors",
+                              selected
+                                ? "border-arcane"
+                                : "border-mist/30 hover:border-arcane/50"
                             )}
                             title={c.title}
                           >
@@ -356,59 +360,26 @@ export function Game() {
         </AnimatePresence>
       </div>
 
-      {/* controls */}
-      <div className="border-t border-arcane/20 bg-void-deep/80 backdrop-blur-sm">
-        {/* disable controls until mulligan is done */}
-        {!inMulligan && !inBattlefieldPick && <GameControls />}
-      </div>
+      <div className="bg-void-deep/60">
+        <div className="h-14 px-4 flex items-center justify-between gap-4">
+          <div className="flex items-center gap-4 min-w-0">
+            <RunesDisplay runes={myPlayer?.runesInPlay || []} />
+            <div className="flex items-baseline gap-2">
+              <span className="text-[10px] uppercase tracking-wider text-text-dim/60">
+                Energy
+              </span>
+              <span className="text-shurima font-display text-lg tabular-nums">
+                {myPlayer?.energy || 0}
+              </span>
+            </div>
+          </div>
 
-      {/* runes display */}
-      <div className="h-16 px-6 flex items-center gap-3 border-t border-arcane/20 bg-void-deep/50">
-        <span className="text-xs text-text-dim uppercase tracking-wider mr-2">Runes:</span>
-        <RunesDisplay runes={myPlayer?.runesInPlay || []} />
-      </div>
-
-      {/* hand */}
-      <div className="h-40 border-t border-arcane/20 bg-void-deep">
-        <PlayerHand cards={myPlayer?.hand || []} />
-      </div>
-
-      {/* player info bar */}
-      <div className="h-16 px-6 flex items-center justify-between border-t border-arcane/20 bg-void-deep backdrop-blur-sm">
-        <div className="flex items-center gap-4">
-          <motion.div
-            animate={{ scale: [1, 1.2, 1] }}
-            transition={{ duration: 1, repeat: Infinity, repeatDelay: 2 }}
-            className="w-3 h-3 rounded-full bg-success"
-          />
-          <span className="font-display text-lg text-arcane uppercase tracking-wider">
-            {myPlayer?.name || "You"}
-          </span>
+          {!inMulligan && !inBattlefieldPick && <GameControls />}
         </div>
-        <div className="flex items-center gap-8">
-          <div className="text-center">
-            <p className="text-xs text-text-dim uppercase tracking-wider">Score</p>
-            <p className="font-display text-2xl text-arcane transition-all duration-300">{myPlayer?.score || 0}</p>
-          </div>
-          <div className="h-8 w-px bg-arcane/20" />
-          <div className="text-center">
-            <p className="text-xs text-text-dim uppercase tracking-wider">Hand</p>
-            <p className="font-display text-xl text-text transition-all duration-300">{myPlayer?.hand?.length || 0}</p>
-          </div>
-          <div className="h-8 w-px bg-arcane/20" />
-          <div className="text-center">
-            <p className="text-xs text-text-dim uppercase tracking-wider">Deck</p>
-            <p className="font-display text-xl text-text transition-all duration-300">{myPlayer?.mainDeckSize || 0}</p>
-          </div>
+
+        <div className="h-36 px-4">
+          <PlayerHand cards={myPlayer?.hand || []} />
         </div>
-        <Button
-          variant="ghost"
-          size="sm"
-          onClick={() => window.location.href = "/"}
-          className="text-text-dim hover:text-danger"
-        >
-          <LogOut size={18} />
-        </Button>
       </div>
     </div>
   );


### PR DESCRIPTION
Complete UI redesign of the Riftbound game interface to create a cleaner, more minimal aesthetic with better information hierarchy.

## Key Changes

**RunesDisplay** — Runes now group and stack by color like overlapping cards, showing ready/total counts per color. Tap interactions gated by turn ownership and main phase.

**Game Page Layout** — Replaced heavy info bars with a minimal top bar displaying opponent status and turn info. Integrated bottom section combines runes display, energy meter, controls, and hand in a cohesive flow. Mulligan and battlefield-pick overlays softened with reduced visual clutter.

**GameBoard** — Battlefield zones use subtle background tints instead of heavy borders. Units organized with minimal labels and soft dividers. Bases simplified to clean panels.

**GameLog** — Collapsible by default (just an icon button), expands to a compact panel showing entry dots + messages. Less intrusive and takes minimal space.

**GameControls & PlayerHand** — Streamlined controls with smaller buttons and reduced animations. Hand cards use subtle hover lifting instead of flashy effects.

**CSS Updates** — Disabled heavy animations like `pulse-contested` and `rune-shimmer`. Added `.hover-lift` utility for smooth card interactions.

**Chain Display** — New component with safe optional field handling for future chain system integration.

<a href="https://capy.ai/project/a2088422-0191-4c13-8c45-d46a8d4cb6af/task/1bf45e44-195b-4e3f-b585-541836db165e"><img alt="Review with Capy" src="https://capy.ai/review-with-capy.svg"></a>