### PR TITLE
Fix critical multiplayer bugs: game state sync and UI layout

### DIFF
--- a/riftbound/backend/blueprints/gateway/socket.py
+++ b/riftbound/backend/blueprints/gateway/socket.py
@@ -59,6 +59,16 @@ async def game_socket(request, ws: WebsocketImplProtocol, game_id: str):
             "connected": True,
         },
     }, exclude=player_id)
+
+    if session.status == "active" and session.state:
+        for pid, conn in list(session.connections.items()):
+            try:
+                await conn.send(json.dumps({
+                    "type": "game_state",
+                    "state": session.to_dict(for_player=pid),
+                }))
+            except Exception as e:
+                logger.error(f"failed to send state to {pid}: {e}")
     
     # register engine event handler
     if session.engine:

--- a/riftbound/frontend/src/components/CardImage.tsx
+++ b/riftbound/frontend/src/components/CardImage.tsx
@@ -35,7 +35,7 @@ export function CardImage({
       onClick={onClick}
       className={cn(
         "relative transition-all duration-300",
-        sizeClasses[size],
+        !className?.includes("w-") && sizeClasses[size],
         orientation === "landscape" ? "aspect-[4/3]" : "aspect-[3/4]",
         onClick && "cursor-pointer hover:scale-105",
         selected && "ring-2 ring-arcane shadow-[0_0_30px_rgba(200,170,110,0.6)]",
@@ -51,7 +51,7 @@ export function CardImage({
         alt={card.title}
         loading="lazy"
         className={cn(
-          "w-full h-full object-cover rounded-sm transition-all duration-300",
+          "w-full h-full object-contain rounded-sm transition-all duration-300",
           "border border-arcane/20",
           onClick && "hover:border-arcane/60"
         )}

--- a/riftbound/frontend/src/pages/Game.tsx
+++ b/riftbound/frontend/src/pages/Game.tsx
@@ -247,7 +247,7 @@ export function Game() {
               <motion.div
                 initial={{ scale: 0.98, y: 10 }}
                 animate={{ scale: 1, y: 0 }}
-                className="w-full max-w-3xl bg-void-deep/95 border border-mist/20 rounded-lg p-6 shadow-[0_0_60px_rgba(0,0,0,0.8)]"
+                className="w-full max-w-4xl bg-void-deep/95 border border-mist/20 rounded-lg p-6 shadow-[0_0_60px_rgba(0,0,0,0.8)]"
               >
                 <h2 className="font-display text-xl uppercase tracking-wider text-arcane mb-2">
                   choose your battlefield
@@ -267,16 +267,20 @@ export function Game() {
                     <span className="text-sm">waiting for opponent...</span>
                   </div>
                 ) : (
-                  <div className="grid grid-cols-3 gap-4">
+                  <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
                     {myBattlefieldOptions.map((c) => (
                       <button
                         key={c.id}
                         onClick={() => chooseBattlefield(c.id)}
                         disabled={bfSubmitting}
-                        className="rounded-md overflow-hidden border border-mist/30 hover:border-arcane/50 transition-colors"
+                        className="rounded-md overflow-hidden border border-mist/30 hover:border-arcane/50 transition-colors aspect-[4/3]"
                         title={c.title}
                       >
-                        <CardImage card={c} size="md" className="w-full" />
+                        <CardImage
+                          card={c}
+                          size="lg"
+                          className="w-full h-full object-contain"
+                        />
                       </button>
                     ))}
                   </div>


### PR DESCRIPTION
Fixes three critical bugs preventing multiplayer games from functioning:

**Bug #1 (CRITICAL):** Player 1 never receives the game state when Player 2 joins. When Player 2 connects via WebSocket after joining the game, the server now broadcasts the full `game_state` to all connected players, ensuring both players see the active setup and can proceed with battlefield selection.

**Bug #2:** Battlefield selection modal cuts off landscape cards. The modal container is now wider (max-w-4xl), the grid is responsive (grid-cols-1 sm:grid-cols-3), and cards use full-size rendering with `object-contain` to prevent clipping.

**Bug #3 (downstream):** Turn progression fails because players are missing game state information. This resolves automatically once Bug #1 is fixed, allowing players to see mulligan and complete the setup sequence.

Changes:
- Backend: Add per-player game_state broadcast when session becomes active (socket.py)
- Frontend: Widen battlefield selection modal and improve card sizing (Game.tsx, CardImage.tsx)
- Frontend: Fix CardImage to respect explicit width classes and use object-contain rendering

<a href="https://capy.ai/project/a2088422-0191-4c13-8c45-d46a8d4cb6af/task/14af2221-1122-41d9-a02a-4243d33500d5"><img alt="Review with Capy" src="https://capy.ai/review-with-capy.svg"></a>